### PR TITLE
Merge official JES into mine, to see if it still works

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -43,8 +43,8 @@
 
     <!-- Other metadata -->
     <property name="jes.vendor"         value="Georgia Institute of Technology" />
-    <property name="jes.copyright"      value="© 2014 Matthew Frazier, Mark Guzdial, and others" />
-    <property name="jes.version"        value="5.01" />
+    <property name="jes.copyright"      value="© 2015 Matthew Frazier, Mark Guzdial, and others" />
+    <property name="jes.version"        value="5.02" />
     <property name="jes.release"        value="${jes.version}${release}" />
 
     <tstamp>

--- a/jes/python/jes/core/interpreter/__init__.py
+++ b/jes/python/jes/core/interpreter/__init__.py
@@ -26,7 +26,7 @@ class Interpreter(object):
         self.lock = Lock()
         self.isRunning = False
         self.runningThread = None
-        self._threadLaunched = Semaphore(0)
+        #self._threadLaunched = Semaphore(0)
 
         self.debugger = Debugger(self)
         self.debugMode = False
@@ -124,7 +124,7 @@ class Interpreter(object):
         lock before returning. This is used to serialize execution.
         """
         thread.start()
-        self._threadLaunched.acquire()
+        #self._threadLaunched.acquire()
         return thread
 
     def stopThread(self):
@@ -147,7 +147,7 @@ class InterpreterThread(Thread):
 
         with terp.lock:
             terp.runningThread = self
-            terp._threadLaunched.release()
+            #terp._threadLaunched.release()
 
             excRecord = None
             terp.namespace.update(self.extraVars)

--- a/jes/python/jes/gui/commandwindow/__init__.py
+++ b/jes/python/jes/gui/commandwindow/__init__.py
@@ -15,6 +15,7 @@ from .pane import CommandWindowPane
 from .prompt import promptService
 from jes.gui.components.actions import methodAction
 from jes.gui.components.threading import threadsafe
+from media import * # Debugging
 
 class CommandWindowController(object):
     """
@@ -130,6 +131,8 @@ class CommandWindowController(object):
             text = self._history.commit()
             if cb is not None:
                 cb(text)
+            else:
+                raise Exception("A prompt is None.")
 
     @methodAction(name="Clear command window")
     @threadsafe

--- a/jes/python/jes/gui/filemanager/__init__.py
+++ b/jes/python/jes/gui/filemanager/__init__.py
@@ -121,7 +121,7 @@ class FileManager(object):
 
         try:
             with open(filename, 'r') as fd:
-                self.editor.setText(fd.read().decode('utf8', 'replace'))
+                self.editor.setText(fd.read().encode('ascii','replace')) #decode('utf8', 'replace'))
         except EnvironmentError, exc:
             self.showErrorMessage(
                 "Error opening file", "Could not open the file", filename, exc

--- a/jes/python/jes/gui/mainwindow.py
+++ b/jes/python/jes/gui/mainwindow.py
@@ -572,7 +572,7 @@ class JESUI(swing.JFrame, FocusListener):
         elif (actionCommand == LOAD_BUTTON_CAPTION) or (actionCommand == COMMAND_LOAD):
             if self.editor.modified:
                 if JESConfig.getInstance().getBooleanProperty(JESConfig.CONFIG_AUTOSAVEONRUN):
-                    self.program.fileManager.saveFile()
+                    self.program.fileManager.saveAction()
                     self.editor.document.removeErrorHighlighting()
                     self.program.loadFile()
                 elif self.program.fileManager.continueAfterSaving(PROMPT_LOAD_MESSAGE):


### PR DESCRIPTION
- AutoSave on load now works (in mainwindow.py)
- Flags Unicode on load.
- Removes the semaphore that was serializing access to the interpreter.
  Was leading to lots of hangs.
